### PR TITLE
Remove ethers + typechain files from package.

### DIFF
--- a/evm/package.json
+++ b/evm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashflow/contracts-evm",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "EVM Smart Contracts for Solidity",
   "main": "dist/src/index.js",
   "types": "dist/src/index.ts",
@@ -16,7 +16,6 @@
     "deployed-contracts",
     "types",
     "dist/src",
-    "dist/types",
     "abi"
   ],
   "keywords": [
@@ -45,10 +44,10 @@
     "solidity-coverage": "^0.8.0",
     "ts-node": ">=8.0.0",
     "typechain": "^8.1.0",
-    "typescript": ">=4.5.0"
+    "typescript": ">=4.5.0",
+    "ethers": "^6.4.0"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "4.9.2",
-    "ethers": "^6.4.0"
+    "@openzeppelin/contracts": "4.9.2"
   }
 }

--- a/evm/src/index.ts
+++ b/evm/src/index.ts
@@ -1,5 +1,3 @@
-export * from '../types';
-
 export {
   NetworkName,
   ChainId,


### PR DESCRIPTION
We should not make every downstream package depend on Ethers (v6). We remove the auto-generated files from the package and we move the ethers dependency to dev.

However, in order for the Hardhat config to compile properly, we need the auto-generated files. Therefore, we leave those in the rrepo.

Test Plan:
- generated package with `npm pack`
- inspected contents of package