### PR TITLE
Tasks to handle pool creator authorization.

### DIFF
--- a/evm/hardhat.config.ts
+++ b/evm/hardhat.config.ts
@@ -13,6 +13,7 @@ import { NetworkUserConfig } from 'hardhat/types';
 
 import './tasks/core';
 import './tasks/deploy';
+import './tasks/operations';
 import './tasks/integration-tests/wormhole-setup';
 import './tasks/integration-tests/wormhole-trade';
 

--- a/evm/tasks/operations.ts
+++ b/evm/tasks/operations.ts
@@ -1,0 +1,44 @@
+import { task } from 'hardhat/config';
+import {
+  getDeployedContractMetadata,
+  getNetworkConfigFromHardhatRuntimeEnvironment,
+} from './utils';
+
+task(
+  'factory:update-pool-creator-authorization',
+  'Updates Pool Creator Authorization',
+)
+  .addParam('poolCreator', 'The address of the Pool creator')
+  .addFlag('revoke', 'Whether to revoke authorization')
+  .setAction(async (taskArgs, hre) => {
+    const networkConfig = getNetworkConfigFromHardhatRuntimeEnvironment(hre);
+
+    const factoryContractMetadata = getDeployedContractMetadata(
+      'IHashflowFactory',
+      networkConfig.name,
+    );
+
+    if (!factoryContractMetadata) {
+      throw new Error(
+        `Could not find Factory deployment metadata for ${networkConfig.name}`,
+      );
+    }
+
+    const hashflowFactoryContract = await hre.ethers.getContractAt(
+      'IHashflowFactory',
+      factoryContractMetadata.address,
+    );
+
+    const { poolCreator } = taskArgs;
+    const authorizationStatus = !taskArgs.revoke;
+
+    const tx = await hashflowFactoryContract.updatePoolCreatorAuthorization(
+      poolCreator,
+      authorizationStatus,
+    );
+    await tx.wait();
+
+    console.log(
+      `Updated authorization for ${poolCreator} to ${authorizationStatus}`,
+    );
+  });


### PR DESCRIPTION
This is a simple task to toggle pool creator authorization.

Test Plan:
- ran a transaction for a Market Maker