### PR TITLE
Upgrade Command Deck

### DIFF
--- a/hashverse-evm/.openzeppelin/goerli.json
+++ b/hashverse-evm/.openzeppelin/goerli.json
@@ -1079,6 +1079,190 @@
           }
         }
       }
+    },
+    "08df116d06d949e628fbe9a7373e320fae2a3746e3ed29658e5e81d7d9023905": {
+      "address": "0xD0c7bb6B1f993BA8aC62a889B19A2fE8D2f27FC0",
+      "txHash": "0x1f02aaff081d439e2f9e1673c32f6d0956de47186a68c8525ff314c8c2394216",
+      "layout": {
+        "solcVersion": "0.8.19",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "renovaAvatar",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_address",
+            "contract": "RenovaCommandDeckBase",
+            "src": "contracts/core/RenovaCommandDeckBase.sol:23"
+          },
+          {
+            "label": "renovaItem",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_address",
+            "contract": "RenovaCommandDeckBase",
+            "src": "contracts/core/RenovaCommandDeckBase.sol:26"
+          },
+          {
+            "label": "hashflowRouter",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_address",
+            "contract": "RenovaCommandDeckBase",
+            "src": "contracts/core/RenovaCommandDeckBase.sol:29"
+          },
+          {
+            "label": "questOwner",
+            "offset": 0,
+            "slot": "104",
+            "type": "t_address",
+            "contract": "RenovaCommandDeckBase",
+            "src": "contracts/core/RenovaCommandDeckBase.sol:32"
+          },
+          {
+            "label": "questDeploymentAddresses",
+            "offset": 0,
+            "slot": "105",
+            "type": "t_mapping(t_bytes32,t_address)",
+            "contract": "RenovaCommandDeckBase",
+            "src": "contracts/core/RenovaCommandDeckBase.sol:35"
+          },
+          {
+            "label": "questIdsByDeploymentAddress",
+            "offset": 0,
+            "slot": "106",
+            "type": "t_mapping(t_address,t_bytes32)",
+            "contract": "RenovaCommandDeckBase",
+            "src": "contracts/core/RenovaCommandDeckBase.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "107",
+            "type": "t_array(t_uint256)16_storage",
+            "contract": "RenovaCommandDeckBase",
+            "src": "contracts/core/RenovaCommandDeckBase.sol:41"
+          },
+          {
+            "label": "itemMerkleRoots",
+            "offset": 0,
+            "slot": "123",
+            "type": "t_mapping(t_bytes32,t_bytes32)",
+            "contract": "RenovaCommandDeck",
+            "src": "contracts/core/RenovaCommandDeck.sol:15"
+          },
+          {
+            "label": "_mintedItems",
+            "offset": 0,
+            "slot": "124",
+            "type": "t_mapping(t_bytes32,t_mapping(t_address,t_bool))",
+            "contract": "RenovaCommandDeck",
+            "src": "contracts/core/RenovaCommandDeck.sol:17"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "125",
+            "type": "t_array(t_uint256)16_storage",
+            "contract": "RenovaCommandDeck",
+            "src": "contracts/core/RenovaCommandDeck.sol:20"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)16_storage": {
+            "label": "uint256[16]",
+            "numberOfBytes": "512"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bytes32)": {
+            "label": "mapping(address => bytes32)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_address)": {
+            "label": "mapping(bytes32 => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_bytes32)": {
+            "label": "mapping(bytes32 => bytes32)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_mapping(t_address,t_bool))": {
+            "label": "mapping(bytes32 => mapping(address => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/hashverse-evm/.openzeppelin/mainnet.json
+++ b/hashverse-evm/.openzeppelin/mainnet.json
@@ -1079,6 +1079,190 @@
           }
         }
       }
+    },
+    "08df116d06d949e628fbe9a7373e320fae2a3746e3ed29658e5e81d7d9023905": {
+      "address": "0x70F2C0330528000BA806aE8F4254B45Ea980a34c",
+      "txHash": "0x266b80e5d7d11bf298bef9c0cf77ad45466cd7cca1a844d2fee13c45425d6ad8",
+      "layout": {
+        "solcVersion": "0.8.19",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "renovaAvatar",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_address",
+            "contract": "RenovaCommandDeckBase",
+            "src": "contracts/core/RenovaCommandDeckBase.sol:23"
+          },
+          {
+            "label": "renovaItem",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_address",
+            "contract": "RenovaCommandDeckBase",
+            "src": "contracts/core/RenovaCommandDeckBase.sol:26"
+          },
+          {
+            "label": "hashflowRouter",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_address",
+            "contract": "RenovaCommandDeckBase",
+            "src": "contracts/core/RenovaCommandDeckBase.sol:29"
+          },
+          {
+            "label": "questOwner",
+            "offset": 0,
+            "slot": "104",
+            "type": "t_address",
+            "contract": "RenovaCommandDeckBase",
+            "src": "contracts/core/RenovaCommandDeckBase.sol:32"
+          },
+          {
+            "label": "questDeploymentAddresses",
+            "offset": 0,
+            "slot": "105",
+            "type": "t_mapping(t_bytes32,t_address)",
+            "contract": "RenovaCommandDeckBase",
+            "src": "contracts/core/RenovaCommandDeckBase.sol:35"
+          },
+          {
+            "label": "questIdsByDeploymentAddress",
+            "offset": 0,
+            "slot": "106",
+            "type": "t_mapping(t_address,t_bytes32)",
+            "contract": "RenovaCommandDeckBase",
+            "src": "contracts/core/RenovaCommandDeckBase.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "107",
+            "type": "t_array(t_uint256)16_storage",
+            "contract": "RenovaCommandDeckBase",
+            "src": "contracts/core/RenovaCommandDeckBase.sol:41"
+          },
+          {
+            "label": "itemMerkleRoots",
+            "offset": 0,
+            "slot": "123",
+            "type": "t_mapping(t_bytes32,t_bytes32)",
+            "contract": "RenovaCommandDeck",
+            "src": "contracts/core/RenovaCommandDeck.sol:15"
+          },
+          {
+            "label": "_mintedItems",
+            "offset": 0,
+            "slot": "124",
+            "type": "t_mapping(t_bytes32,t_mapping(t_address,t_bool))",
+            "contract": "RenovaCommandDeck",
+            "src": "contracts/core/RenovaCommandDeck.sol:17"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "125",
+            "type": "t_array(t_uint256)16_storage",
+            "contract": "RenovaCommandDeck",
+            "src": "contracts/core/RenovaCommandDeck.sol:20"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)16_storage": {
+            "label": "uint256[16]",
+            "numberOfBytes": "512"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bytes32)": {
+            "label": "mapping(address => bytes32)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_address)": {
+            "label": "mapping(bytes32 => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_bytes32)": {
+            "label": "mapping(bytes32 => bytes32)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_mapping(t_address,t_bool))": {
+            "label": "mapping(bytes32 => mapping(address => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/hashverse-evm/.openzeppelin/polygon-mumbai.json
+++ b/hashverse-evm/.openzeppelin/polygon-mumbai.json
@@ -971,6 +971,162 @@
           }
         }
       }
+    },
+    "1bf21899fc37660b724fd3509a0450a460b83cd347245425c49c03c9601b4494": {
+      "address": "0x0A93e8321154E1188ee1aABF2dFC6F9fE05a867E",
+      "txHash": "0xa9ef6ee9d18e5353407a1b435ee3d3b0d60a5a929dd46027e4402ec7ad18891f",
+      "layout": {
+        "solcVersion": "0.8.19",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "renovaAvatar",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_address",
+            "contract": "RenovaCommandDeckBase",
+            "src": "contracts/core/RenovaCommandDeckBase.sol:23"
+          },
+          {
+            "label": "renovaItem",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_address",
+            "contract": "RenovaCommandDeckBase",
+            "src": "contracts/core/RenovaCommandDeckBase.sol:26"
+          },
+          {
+            "label": "hashflowRouter",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_address",
+            "contract": "RenovaCommandDeckBase",
+            "src": "contracts/core/RenovaCommandDeckBase.sol:29"
+          },
+          {
+            "label": "questOwner",
+            "offset": 0,
+            "slot": "104",
+            "type": "t_address",
+            "contract": "RenovaCommandDeckBase",
+            "src": "contracts/core/RenovaCommandDeckBase.sol:32"
+          },
+          {
+            "label": "questDeploymentAddresses",
+            "offset": 0,
+            "slot": "105",
+            "type": "t_mapping(t_bytes32,t_address)",
+            "contract": "RenovaCommandDeckBase",
+            "src": "contracts/core/RenovaCommandDeckBase.sol:35"
+          },
+          {
+            "label": "questIdsByDeploymentAddress",
+            "offset": 0,
+            "slot": "106",
+            "type": "t_mapping(t_address,t_bytes32)",
+            "contract": "RenovaCommandDeckBase",
+            "src": "contracts/core/RenovaCommandDeckBase.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "107",
+            "type": "t_array(t_uint256)16_storage",
+            "contract": "RenovaCommandDeckBase",
+            "src": "contracts/core/RenovaCommandDeckBase.sol:41"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "123",
+            "type": "t_array(t_uint256)16_storage",
+            "contract": "RenovaCommandDeckSatellite",
+            "src": "contracts/core/RenovaCommandDeckSatellite.sol:17"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)16_storage": {
+            "label": "uint256[16]",
+            "numberOfBytes": "512"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bytes32)": {
+            "label": "mapping(address => bytes32)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_address)": {
+            "label": "mapping(bytes32 => address)",
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Upgrading the command deck on 3 networks:
- Goerli
- Mumbai
- Ethereum

This is following minor comments from the Quanstamp audit (which will be uploaded shortly).

Test Plan:
- upgraded contracts
- verified contracts on the explorers